### PR TITLE
New `CredentialProvider` for AWS’ `credential_process` facility

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,2 @@
+{:config-paths ["noprompt/meander"]
+ :skip-comments true}

--- a/.clj-kondo/noprompt/meander/config.edn
+++ b/.clj-kondo/noprompt/meander/config.edn
@@ -1,0 +1,8 @@
+;; See:
+;;   https://github.com/clj-kondo/clj-kondo/issues/1647
+;;   https://clojurians-log.clojureverse.org/clj-kondo/2022-04-03
+{:linters {:unresolved-symbol {:exclude [(meander.epsilon/match)
+                                         (meander.epsilon/find)
+                                         (meander.epsilon/search)
+                                         (meander.epsilon/rewrite)]}
+           :not-a-function {:level :off}}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+
 ### Changed
+
 - Add a new arity to `make-widget-async` to provide a different widget shape.
+
+### Added
+
+- A new `CredentialsProvider` that supports `credential_process`
+
 
 ## [0.1.1] - 2021-10-11
 ### Changed
@@ -20,5 +27,5 @@ All notable changes to this project will be documented in this file. This change
 - Files from the new template.
 - Widget maker public API - `make-widget-sync`.
 
-[Unreleased]: https://github.com/latacora/awsvault-cred-provider/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/latacora/awsvault-cred-provider/compare/0.1.0...0.1.1
+[Unreleased]: https://github.com/latacora/backsaws/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/latacora/backsaws/compare/0.1.0...0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,22 @@
-# Change Log
-All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+# Changelog
+
+All notable changes to this project will be documented in this file, which follows the conventions
+of [Keep a Changelog].
+
 
 ## [Unreleased]
 
-### Changed
-
-- Add a new arity to `make-widget-async` to provide a different widget shape.
-
 ### Added
 
-- A new `CredentialsProvider` that supports `credential_process`
+- An alternative to `invoke` named `paginated-invoke` that automatically and seamlessly handles
+  pagination
+- A [`CredentialsProvider`][CredentialsProvider] that supports [`aws-vault`][aws-vault]
+- A [`CredentialsProvider`][CredentialsProvider] that supports
+  [`credential_process`][credential_process] ([#1])
 
 
-## [0.1.1] - 2021-10-11
-### Changed
-- Documentation on how to make the widgets.
-
-### Removed
-- `make-widget-sync` - we're all async, all the time.
-
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2021-10-11
-### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
-
-[Unreleased]: https://github.com/latacora/backsaws/compare/0.1.1...HEAD
-[0.1.1]: https://github.com/latacora/backsaws/compare/0.1.0...0.1.1
+[#1]: https://github.com/latacora/backsaws/pull/1
+[aws-vault]: https://github.com/99designs/aws-vault
+[credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+[CredentialsProvider]: https://github.com/cognitect-labs/aws-api#credentials
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A [`CredentialsProvider`][CredentialsProvider] backed by [`aws-vault`][awsvault]
 A [`CredentialsProvider`][CredentialsProvider] that supports
 [`credential_process`][credential_process].
 
-This requires the [AWS CLI profile] (which could be `default`) to have the key
+This requires the active [AWS CLI profile] (which could be `default`) to have the key
 `credential_process` set to a command that this provider can invoke to get valid credentials.
 
 ```clojure
@@ -60,14 +60,8 @@ This requires the [AWS CLI profile] (which could be `default`) to have the key
   {:op :ListBuckets})
 ```
 
-You can specify the profile name by supplying it as the first argument, for example:
-
-```clojure
-(cp/provider "some-profile-name")
-```
-
-When invoked without arguments `cp/provider` will look for a profile name in the environment
-variable `AWS_PROFILE`, or the Java System Property `aws.profile`, or will fall back to `default`.
+This has been tested with [aws-sso-util] — specifically with its command
+[credential-process][aws-sso-util-credential-process].
 
 
 ## Development
@@ -93,6 +87,8 @@ Distributed under the Eclipse Public License version 1.0.
 
 
 [AWS CLI Profile]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+[aws-sso-util]: https://github.com/benkehoe/aws-sso-util
+[aws-sso-util-credential-process]: https://github.com/benkehoe/aws-sso-util/blob/39cf9431e3ae03dc9d396ff6f4b80c5fc7889c85/docs/credential-process.md
 [awsvault]: https://github.com/99designs/aws-vault
 [CredentialsProvider]: https://github.com/cognitect-labs/aws-api#credentials
 [credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html

--- a/README.md
+++ b/README.md
@@ -31,11 +31,9 @@ Figures out how to paginate an API and do it automagically.
    :request {:ParentId "ou-xyzzy"}})
 ```
 
-## aws-vault cred provider
+## aws-vault `CredentialsProvider`
 
-A credentials provider backed by [`aws-vault`][awsvault].
-
-[awsvault]: https://github.com/99designs/aws-vault
+A [`CredentialsProvider`][CredentialsProvider] backed by [`aws-vault`][awsvault].
 
 ```clojure
 (require '[com.latacora.backsaws.aws-vault :refer [aws-vault-provider]])
@@ -46,18 +44,55 @@ A credentials provider backed by [`aws-vault`][awsvault].
     {:op :ListBuckets :request {}})
 ```
 
+## `credential_process` `CredentialsProvider`
+
+A [`CredentialsProvider`][CredentialsProvider] that supports
+[`credential_process`][credential_process].
+
+This requires the [AWS CLI profile] (which could be `default`) to have the key
+`credential_process` set to a command that this provider can invoke to get valid credentials.
+
+```clojure
+(require '[com.latacora.backsaws.credential-process :as cp])
+
+(aws/invoke
+  (sso/client {:api :s3 :credentials-provider (cp/provider)})
+  {:op :ListBuckets})
+```
+
+You can specify the profile name by supplying it as the first argument, for example:
+
+```clojure
+(cp/provider "some-profile-name")
+```
+
+When invoked without arguments `cp/provider` will look for a profile name in the environment
+variable `AWS_PROFILE`, or the Java System Property `aws.profile`, or will fall back to `default`.
+
+
 ## Development
+
+Run the tests:
+
+    clojure -M:test
 
 Run tests, linters etc for CI:
 
-> clojure -A:deps -T:build ci
+    clojure -A:deps -T:build ci
 
 Deploy to Clojars:
 
-> clojure -A:deps -T:build deploy
+    clojure -A:deps -T:build deploy
+
 
 ## License
 
 Copyright © Latacora
 
 Distributed under the Eclipse Public License version 1.0.
+
+
+[AWS CLI Profile]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
+[awsvault]: https://github.com/99designs/aws-vault
+[CredentialsProvider]: https://github.com/cognitect-labs/aws-api#credentials
+[credential_process]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html

--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,18 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        com.cognitect.aws/api {:mvn/version "0.8.524"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        com.cognitect.aws/api {:mvn/version "0.8.539"}
         meander/epsilon {:mvn/version "0.0.650"}}
  :aliases
  {:test
   {:main-opts ["-m" "kaocha.runner"]
    :extra-paths ["test"]
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
-                org.clojure/test.check {:mvn/version "1.1.0"}
-                com.gfredericks/test.chuck {:mvn/version "0.2.12"}
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.65.1029"}
+                org.clojure/test.check {:mvn/version "1.1.1"}
+                com.gfredericks/test.chuck {:mvn/version "0.2.13"}
 
                 com.cognitect.aws/organizations {:mvn/version "RELEASE"}
                 com.cognitect.aws/s3 {:mvn/version "RELEASE"}}}
   :build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.5.2" :git/sha "8f75b81"}}
+                 {:git/tag "v0.8.0" :git/sha "9bd8b8a"}}
           :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,16 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         com.cognitect.aws/api {:mvn/version "0.8.539"}
-        meander/epsilon {:mvn/version "0.0.650"}}
+        meander/epsilon {:mvn/version "0.0.650"}
+        org.clojure/tools.logging {:mvn/version "1.2.1"}}
  :aliases
  {:test
   {:main-opts ["-m" "kaocha.runner"]
    :extra-paths ["test"]
-   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"]
-   :extra-deps {lambdaisland/kaocha {:mvn/version "1.65.1029"}
+   :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
+              "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/jul-factory"]
+   :extra-deps {lambdaisland/kaocha {:mvn/version "1.65.1029"
+                                     :exclusions [org.slf4j/slf4j-api]}
                 org.clojure/test.check {:mvn/version "1.1.1"}
                 com.gfredericks/test.chuck {:mvn/version "0.2.13"}
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.3</version>
+      <version>1.11.1</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/com/latacora/backsaws/credential_process.clj
+++ b/src/com/latacora/backsaws/credential_process.clj
@@ -1,0 +1,131 @@
+;; This code was copied from the project pod-babashka-aws and then modified by Latacora.
+;;
+;; Original file:
+;; https://github.com/babashka/pod-babashka-aws/blob/81e200692c8b637529cc48f7c51f2e5777c586c5/src/pod/babashka/aws/impl/aws/credentials.clj
+;;
+;; pod-babashka-aws is copyright © 2020 Michiel Borkent, Jeroen van Dijk, Rahul De and Valtteri
+;; Harmainen and is distributed under the Apache License 2.0:
+;; https://github.com/babashka/pod-babashka-aws/blob/81e200692c8b637529cc48f7c51f2e5777c586c5/LICENSE
+;;
+;; Modifications copyright © 2022 Latacora and distributed under the Eclipse Public License 1.0; see
+;; LICENSE in the root of this code repository.
+
+(ns com.latacora.backsaws.credential-process
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [cognitect.aws.config :as config]
+            [cognitect.aws.credentials :as creds]
+            [cognitect.aws.util :as u]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn- parse-cmd
+  "Split string to list of individual space separated arguments.
+  If argument contains space you can wrap it with `'` or `\"`."
+  [s]
+  (loop [s (java.io.StringReader. s)
+         in-double-quotes? false
+         in-single-quotes? false
+         buf (java.io.StringWriter.)
+         parsed []]
+    (let [c (.read s)]
+      (cond
+        (= -1 c) (if (pos? (count (str buf)))
+                   (conj parsed (str buf))
+                   parsed)
+        (= 39 c) ;; single-quotes
+        (if in-single-quotes?
+        ;; exit single-quoted string
+          (recur s in-double-quotes? false (java.io.StringWriter.) (conj parsed (str buf)))
+        ;; enter single-quoted string
+          (recur s in-double-quotes? true buf parsed))
+
+        (= 92 c) ;; assume escaped quote
+        (let [escaped (.read s)
+              buf (doto buf (.write escaped))]
+          (recur s in-double-quotes? in-single-quotes? buf parsed))
+
+        (and (not in-single-quotes?) (= 34 c)) ;; double quote
+        (if in-double-quotes?
+        ;; exit double-quoted string
+          (recur s false in-single-quotes? (java.io.StringWriter.) (conj parsed (str buf)))
+        ;; enter double-quoted string
+          (recur s true in-single-quotes? buf parsed))
+
+        (and (not in-double-quotes?)
+             (not in-single-quotes?)
+             (Character/isWhitespace c))
+        (recur s in-double-quotes? in-single-quotes? (java.io.StringWriter.)
+               (let [bs (str buf)]
+                 (cond-> parsed
+                   (not (str/blank? bs)) (conj bs))))
+        :else (do
+                (.write buf c)
+                (recur s in-double-quotes? in-single-quotes? buf parsed))))))
+
+
+(def windows? (-> (System/getProperty "os.name")
+                  (str/lower-case)
+                  (str/includes? "win")))
+
+
+(defn run-credential-process-cmd [cmd]
+  (let [cmd (parse-cmd cmd)
+        cmd (if windows?
+              (mapv #(str/replace % "\"" "\\\"")
+                    cmd)
+              cmd)
+        ;; _ (binding [*out* *err*] (prn :cmd cmd))
+        {:keys [exit out err]} (apply shell/sh cmd)]
+    (if (zero? exit)
+      out
+      (throw (ex-info (str "Non-zero exit: " (pr-str err)) {})))))
+
+
+(defn get-credentials-via-cmd [cmd]
+  (let [credential-map (json/read-str (run-credential-process-cmd cmd))
+        {:strs [AccessKeyId SecretAccessKey SessionToken Expiration]} credential-map]
+    (assert (and AccessKeyId SecretAccessKey))
+    {"aws_access_key_id" AccessKeyId
+     "aws_secret_access_key" SecretAccessKey
+     "aws_session_token" SessionToken
+     :Expiration Expiration}))
+
+
+(defn provider
+  "Like profile-credentials-provider but with support for credential_process
+
+   See https://github.com/cognitect-labs/aws-api/issues/73"
+  ([]
+   (provider (or (u/getenv "AWS_PROFILE")
+                 (u/getProperty "aws.profile")
+                 "default")))
+
+  ([profile-name]
+   (provider profile-name (or (io/file (u/getenv "AWS_CREDENTIAL_PROFILES_FILE"))
+                              (io/file (u/getProperty "user.home") ".aws" "credentials"))))
+
+  ([profile-name ^java.io.File f]
+   (creds/auto-refreshing-credentials
+    (reify creds/CredentialsProvider
+      (fetch [_]
+        (when (.exists f)
+          (try
+            (let [profile (get (config/parse f) profile-name)
+                  profile (if-let [cmd (get profile "credential_process")]
+                            (merge profile (get-credentials-via-cmd cmd))
+                            profile)]
+              (creds/valid-credentials
+               {:aws/access-key-id     (get profile "aws_access_key_id")
+                :aws/secret-access-key (get profile "aws_secret_access_key")
+                :aws/session-token     (get profile "aws_session_token")
+                ::creds/ttl (creds/calculate-ttl profile)}
+               "aws profiles file"))
+            (catch Throwable t
+              (log/error t "Error fetching credentials from aws profiles file")
+              {}))))))))

--- a/src/com/latacora/backsaws/credential_process.clj
+++ b/src/com/latacora/backsaws/credential_process.clj
@@ -80,7 +80,7 @@
               (mapv #(str/replace % "\"" "\\\"")
                     cmd)
               cmd)
-        ;; _ (binding [*out* *err*] (prn :cmd cmd))
+        _ (log/debugf "command: %s" cmd)
         {:keys [exit out err]} (apply shell/sh cmd)]
     (if (zero? exit)
       out
@@ -97,7 +97,6 @@
      :Expiration Expiration}))  ;; Expiration is used by creds/calculate-ttl
 
 
-;; TODO: Why does this sometimes return nil and sometimes return an empty map?
 ;; TODO: Maybe this should look for `credential_process` in both the CLI config file *and* its creds
 ;;       file (first checking one and then, if not found, falling back to the other).
 (defn provider
@@ -131,5 +130,4 @@
               (log/debugf "Creds: %s" creds)
               (creds/valid-credentials creds "credential_process"))
             (catch Throwable t
-              (log/error t "Error fetching credentials from credential_process")
-              {}))))))))
+              (log/error t "Error fetching credentials from credential_process")))))))))

--- a/test/com/latacora/backsaws/credential_process_test.clj
+++ b/test/com/latacora/backsaws/credential_process_test.clj
@@ -1,0 +1,95 @@
+(ns com.latacora.backsaws.credential-process-test
+  (:require [clojure.data.json :as json]
+            [clojure.java.shell :as sh]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.logging :as log]
+            [cognitect.aws.credentials :as awscreds]
+            [com.latacora.backsaws.credential-process :as cp]
+            [meander.epsilon :as m])
+  (:import [java.io File]
+           [java.time Instant]
+           [java.util.logging Level Logger]))
+
+
+;; If you’re debugging these tests change this to e.g. Level/FINER
+(def log-level Level/OFF)
+
+(run! #(.setLevel (Logger/getLogger %) log-level)
+      ["com.latacora.backsaws.credential-process" (str *ns*)])
+
+(->> (Logger/getLogger "")
+     (.getHandlers)
+     (run! #(.setLevel % log-level)))
+
+
+(defn write-config-file
+  [profile]
+  (let [tf (File/createTempFile "test" "awsconfig")
+        contents (format (str "[default]\n"
+                              "foo=bar\n"
+                              "\n"
+                              "[profile %s]\n"
+                              "credential_process = aws-sso-util credential-process --profile %s\n")
+                         profile profile)]
+    (spit tf contents)
+    (log/infof "Wrote config file to %s" tf)
+    tf))
+
+
+(def fake-result
+  "Fake result of the invocation of the credential_process, as per
+   https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html"
+  {:Version 1
+   :AccessKeyId "ASIA"
+   :SecretAccessKey "xyzzy"
+   :SessionToken "iddqd"
+   :Expiration (-> (Instant/now) (.plusSeconds 3600) str)})
+
+
+(def fake-process-output
+  (json/write-str fake-result))
+
+
+(defn fake-sh!
+  [ctx & args]
+  (let [expected-profile (->> @ctx (filter #(-> % :type (= :profile))) last :value)
+        profile (m/match args
+                  ("aws-sso-util" "credential-process" "--profile" ?profile)
+                  ?profile)]
+    (is (= expected-profile profile))
+    (swap! ctx conj {:type :call :fn 'fake-sh :args args})
+    {:out fake-process-output
+     :exit 0
+     :err "we good"}))
+
+
+(deftest e2e-happy-path-test
+  (let [profile (str (gensym))
+        config-file (write-config-file profile)
+        ctx (atom [{:type :profile :value profile}])
+        n-calls (fn [] (->> @ctx (filter #(-> % :type (= :call))) count))]
+    (with-redefs [sh/sh (partial fake-sh! ctx)]
+      (let [provider (cp/provider profile config-file)]
+        (testing "instantiating does not fetch creds"
+          (is (zero? (n-calls))))
+
+        (testing "first fetch calls aws-sso-util"
+          (let [result (awscreds/fetch provider)
+                {:aws/keys [access-key-id secret-access-key session-token]} result]
+            (is (= "ASIA" access-key-id))
+            (is (= "xyzzy" secret-access-key))
+            (is (= "iddqd" session-token))
+            (is (<= 3000 (::awscreds/ttl result) 3600))
+            (is (= 1 (n-calls)))))
+
+        (testing "fetch results are cached"
+          (awscreds/fetch provider)
+          (is (= 1 (n-calls))))))))
+
+
+(deftest e2e-sad-path-test
+  (with-redefs [sh/sh (constantly {:out "" :exit 1 :err "ruh roh"})]
+    (let [profile (str (gensym))
+          config-file (write-config-file profile)
+          provider (cp/provider profile config-file)]
+      (is (nil? (awscreds/fetch provider))))))

--- a/test/manual/test_credential_process_manual.clj
+++ b/test/manual/test_credential_process_manual.clj
@@ -1,0 +1,33 @@
+#!/bin/sh
+#_(
+   set -eu
+   
+   #_ YO Make sure you run this from the root of the repo!
+   
+   echo "Using AWS profile $AWS_PROFILE"
+
+   #_DEPS is same format as deps.edn. Multiline is okay.
+   DEPS='
+   {:deps {org.clojure/clojure         {:mvn/version "1.11.1"}
+           com.cognitect.aws/api       {:mvn/version "0.8.539"}
+           com.cognitect.aws/endpoints {:mvn/version "1.1.12.192"}
+           com.cognitect.aws/s3        {:mvn/version "822.2.1109.0"}
+           latacora/backsaws           {:local/root  "./"}}}
+   '
+
+   #_You can put other options here
+   OPTS='
+   -J-Xms256m -J-Xmx256m -J-client
+   '
+
+exec clojure $OPTS -Sdeps "$DEPS" -M "$0" "$@"
+)
+
+(require '[cognitect.aws.client.api :as aws])
+(require '[com.latacora.backsaws.credential-process :as cp])
+
+(-> (aws/client {:api :s3, :credentials-provider (cp/provider)})
+    (aws/invoke {:op :ListBuckets})
+    (:Buckets)
+    (->> (map :Name))
+    (println))


### PR DESCRIPTION
For [CETUS-61](https://latacora.atlassian.net/browse/CETUS-61).

This is working for me with the included manual test, when used with an AWS CLI profile created by `aws-sso-util`.

e.g. from the root of the repo:

```shell
backsaws $ AWS_PROFILE=sso.nas.read-prod test/manual/test_credential_process_manual.clj
Using AWS profile sso.nas.read-prod
2022-04-18 20:57:07.434:INFO::main: Logging initialized @2958ms to org.eclipse.jetty.util.log.StdErrLog
(latacora-cetus-nas-reports latacora-cetus-prod-nas-logs … <redacted>)
```

---

CETUS-61