### PR TITLE
Fix pagination (and support Cost Explorer) 💥 BREAKING CHANGE 💥 

### DIFF
--- a/.clj-kondo/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
+++ b/.clj-kondo/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
@@ -1,0 +1,19 @@
+(ns clj-kondo.com.gfredericks.test.chuck.checking
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn checking
+  [{{:keys [children]} :node}]
+  (let [[_checking desc & opt+bindings+body] children
+        [opts binding-vec & body]             (if (api/vector-node? (first opt+bindings+body))
+                                                (into [(api/map-node {})] opt+bindings+body)
+                                                opt+bindings+body)]
+    (when-not (even? (count (:children binding-vec)))
+      (throw (ex-info "checking requires an even number of bindings" {})))
+    {:node (api/list-node
+            (list*
+             (api/token-node 'let)
+             (api/vector-node (into [(api/token-node (symbol (gensym "_checking-desc"))) desc]
+                                    (:children binding-vec)))
+             opts
+             body))}))

--- a/.clj-kondo/com.gfredericks/test.chuck/config.edn
+++ b/.clj-kondo/com.gfredericks/test.chuck/config.edn
@@ -1,0 +1,4 @@
+{:hooks
+ {:analyze-call
+  {com.gfredericks.test.chuck.clojure-test/checking
+   clj-kondo.com.gfredericks.test.chuck.checking/checking}}}

--- a/.clj-kondo/instaparse/config.edn
+++ b/.clj-kondo/instaparse/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {instaparse.macros/defclone clojure.core/def
+           instaparse.macros/set-global-var! clojure.core/set!}}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,19 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           java-package: jre
       - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@5.1
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
-          cli: 1.11.1.1113
+          cli: 1.11.3.1463
           github-token: ${{ secrets.GITHUB_TOKEN }}  # To avoid rate limit errors
       - name: Cache Dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gitlibs

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /checkouts
 /classes
 /target
+vs-code.edn

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        com.cognitect.aws/api {:mvn/version "0.8.615"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.3"}
+        com.cognitect.aws/api {:mvn/version "0.8.692"}
         meander/epsilon {:mvn/version "0.0.650"}
-        org.clojure/tools.logging {:mvn/version "1.2.4"}
-        babashka/fs {:mvn/version "0.2.12"}
-        instaparse/instaparse {:mvn/version "1.4.12"}}
+        org.clojure/tools.logging {:mvn/version "1.3.0"}
+        babashka/fs {:mvn/version "0.5.21"}
+        instaparse/instaparse {:mvn/version "1.5.0"}}
  :aliases
  {:test
   ;; This profile doesn’t use :main-opts to start the test runner because that prevents some IDEs
@@ -14,13 +14,14 @@
    :jvm-opts ["-XX:-OmitStackTraceInFastThrow"
               "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/jul-factory"]
    :extra-deps
-   {lambdaisland/kaocha {:mvn/version "1.71.1119" :exclusions [org.slf4j/slf4j-api]}
+   {lambdaisland/kaocha {:mvn/version "1.91.1392" :exclusions [org.slf4j/slf4j-api]}
     org.clojure/test.check {:mvn/version "1.1.1"}
-    com.gfredericks/test.chuck {:mvn/version "0.2.13"}
-    com.cognitect.aws/endpoints  {:mvn/version "1.1.12.351"}
-    com.cognitect.aws/organizations {:mvn/version "825.2.1262.0"}
-    com.cognitect.aws/s3 {:mvn/version "825.2.1250.0"}
-    com.cognitect.aws/codecommit {:mvn/version "821.2.1107.0"}}}
+    com.gfredericks/test.chuck {:mvn/version "0.2.14"}
+    com.cognitect.aws/endpoints  {:mvn/version "1.1.12.718"}
+    com.cognitect.aws/organizations {:mvn/version "857.2.1574.0"}
+    com.cognitect.aws/s3 {:mvn/version "868.2.1580.0"}
+    com.cognitect.aws/ce {:mvn/version "857.2.1574.0"}
+    com.cognitect.aws/codecommit {:mvn/version "857.2.1574.0"}}}
   :build
-  {:deps {io.github.seancorfield/build-clj {:git/tag "v0.8.5" :git/sha "de693d0"}}
+  {:deps {io.github.seancorfield/build-clj {:git/tag "v0.9.2" :git/sha "9c9f078"}}
    :ns-default build}}}

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/com/latacora/backsaws/pagination.clj
+++ b/src/com/latacora/backsaws/pagination.clj
@@ -5,7 +5,7 @@
    [clojure.set :as set]))
 
 (def ^:private next-markers
-  "Special cases for next page markers. None that most cases are caught my regex."
+  "Special cases for next page markers. Most cases are caught by regex."
   #{:nextToken})
 
 (def ^:private is-truncated-keys

--- a/src/com/latacora/backsaws/pagination.clj
+++ b/src/com/latacora/backsaws/pagination.clj
@@ -176,9 +176,11 @@
   ([client op-map paging-opts]
    (let [{:keys [results truncated? next-request]} paging-opts
          response (aws/invoke client op-map)]
-     (if (truncated? response)
-       (lazy-cat
-        (results response)
-        (let [op-map (update op-map :request next-request response)]
-          (paginated-invoke client op-map paging-opts)))
-       (results response)))))
+     (->
+      (if (truncated? response)
+        (lazy-cat
+         (results response)
+         (let [op-map (update op-map :request next-request response)]
+           (paginated-invoke client op-map paging-opts)))
+        (results response))
+      (with-meta {:paging-opts paging-opts})))))

--- a/src/com/latacora/backsaws/pagination.clj
+++ b/src/com/latacora/backsaws/pagination.clj
@@ -4,10 +4,6 @@
    [meander.epsilon :as m]
    [clojure.set :as set]))
 
-(def ^:private next-markers
-  "Special cases for next page markers. Most cases are caught by regex."
-  #{:nextToken})
-
 (def ^:private is-truncated-keys
   #{:IsTruncated})
 
@@ -103,7 +99,7 @@
            (let [resp-keys (-> response keys set)
                  matches #(for [c resp-keys :when (re-matches % (name c))] c)
                  next-markers (or
-                               (seq (set/intersection resp-keys next-markers))
+                               (seq (set/intersection resp-keys #{:nextToken}))
                                (seq (matches #"Next([A-Za-z]*)*?(Marker|Token)"))
                                (seq (matches #"([A-Za-z]*)*?(Marker|Token)")))]
              (if-not next-markers

--- a/src/com/latacora/backsaws/pagination.clj
+++ b/src/com/latacora/backsaws/pagination.clj
@@ -5,7 +5,8 @@
    [clojure.set :as set]))
 
 (def ^:private next-markers
-  #{:NextToken :NextMarker :nextToken :NextContinuationToken})
+  "Special cases for next page markers. None that most cases are caught my regex."
+  #{:nextToken})
 
 (def ^:private is-truncated-keys
   #{:IsTruncated})
@@ -103,8 +104,8 @@
                  matches #(for [c resp-keys :when (re-matches % (name c))] c)
                  next-markers (or
                                (seq (set/intersection resp-keys next-markers))
-                               (seq (matches #"Next([A-Za-z]*)*?Marker"))
-                               (seq (matches #"([A-Za-z]*)*?Marker")))]
+                               (seq (matches #"Next([A-Za-z]*)*?(Marker|Token)"))
+                               (seq (matches #"([A-Za-z]*)*?(Marker|Token)")))]
              (if-not next-markers
                ::not-paginated
                (let [req-keys (-> request keys set)]

--- a/src/com/latacora/backsaws/pagination.clj
+++ b/src/com/latacora/backsaws/pagination.clj
@@ -171,10 +171,10 @@
   `:next-request` takes the last request (part of the op-map) and last response
   and returns the next request."
   ([client op-map]
-   (let [paging-opts (infer-paging-opts client (:op op-map))]
-     (paginated-invoke client op-map paging-opts)))
+   (paginated-invoke client op-map nil))
   ([client op-map paging-opts]
-   (let [{:keys [results truncated? next-request]} paging-opts
+   (let [inferred (->> op-map :op (infer-paging-opts client))
+         {:keys [results truncated? next-request]} (merge inferred paging-opts)
          response (aws/invoke client op-map)]
      (->
       (if (truncated? response)

--- a/test/com/latacora/backsaws/pagination_test.clj
+++ b/test/com/latacora/backsaws/pagination_test.clj
@@ -23,7 +23,7 @@
 
    [:s3
     :ListObjectVersions
-    {:results (#'p/mapcat-ks* [:DeleteMarkers :Versions])
+    {:results (#'p/mapcat-ks* [:CommonPrefixes :DeleteMarkers :Versions])
      :truncated? :IsTruncated
      :next-request (#'p/next-request-from-mapping
                     {:NextVersionIdMarker :VersionIdMarker
@@ -31,7 +31,7 @@
 
    [:s3
     :ListObjectsV2
-    {:results :Contents
+    {:results (#'p/mapcat-ks* [:CommonPrefixes :Contents])
      :truncated? :IsTruncated
      :next-request (#'p/next-request-from-mapping
                     {:NextContinuationToken :ContinuationToken})}]

--- a/test/com/latacora/backsaws/pagination_test.clj
+++ b/test/com/latacora/backsaws/pagination_test.clj
@@ -47,7 +47,17 @@
     {:results :repositories
      :truncated? (#'p/some-fn* #{:nextToken})
      :next-request (#'p/next-request-from-mapping
-                    {:nextToken :nextToken})}]])
+                    {:nextToken :nextToken})}]
+
+   [:ce
+    :GetCostAndUsage
+    {:results {:com.latacora.backsaws.pagination/mapcat-of
+               [:DimensionValueAttributes
+                :GroupDefinitions
+                :ResultsByTime]}
+     :truncated? (#'p/some-fn* #{:NextPageToken})
+     :next-request (#'p/next-request-from-mapping
+                    {:NextPageToken :NextPageToken})}]])
 
 (def ^:private pagination-ns
   (comp #{(namespace ::p/x)} namespace))


### PR DESCRIPTION
So, some open questions:

1. Can anyone explain how the heck remove-phantom-results was supposed to work?! I have no idea what I was thinking.
1. Supposedly AWS SDK 2.0 does pagination for you. How does it do that? Can we make this be a transition library for things using backsaws/cognitect API?
1. Do we agree CustomPrefixes should be included? Why (not)?