### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,19 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '17'
           java-package: jre
       - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@12.5
+        uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5
         with:
           cli: 1.11.3.1463
           github-token: ${{ secrets.GITHUB_TOKEN }}  # To avoid rate limit errors
       - name: Cache Dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gitlibs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,19 +6,19 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 https://github.com/actions/setup-java/commit/c1e323688fd81a25caa38c78aa6df2d33d3e20d9
         with:
           distribution: temurin
           java-version: '17'
           java-package: jre
       - name: Install Clojure tools
-        uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5
+        uses: DeLaGuardo/setup-clojure@bc7570e912b028bbcc22f457adec7fdf98e2f4ed # 12.5 https://github.com/DeLaGuardo/setup-clojure/commit/bc7570e912b028bbcc22f457adec7fdf98e2f4ed
         with:
           cli: 1.11.3.1463
           github-token: ${{ secrets.GITHUB_TOKEN }}  # To avoid rate limit errors
       - name: Cache Dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4 https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~/.gitlibs


### PR DESCRIPTION
## Summary
- Pins all GitHub Action references to specific commit SHAs for supply chain security
- Preserves original version tags as comments for readability
- No functional changes - actions resolve to the same versions

## Context
This is part of an org-wide audit to improve GitHub Actions supply chain security.

Generated with Claude Code